### PR TITLE
fix: react to slot changes in group #18

### DIFF
--- a/src/auro-accordion-group.js
+++ b/src/auro-accordion-group.js
@@ -12,8 +12,6 @@ import "focus-visible/dist/focus-visible.min.js";
 class AuroAccordionGroup extends LitElement {
   connectedCallback() {
     super.connectedCallback();
-    this.items = Array.from(this.querySelectorAll('auro-accordion'));
-
     this.addEventListener('toggleExpanded', this.handleToggleExpanded);
   }
 
@@ -31,10 +29,17 @@ class AuroAccordionGroup extends LitElement {
     });
   }
 
+  /**
+   * @private Internal function to update items when items are added or removed from the slot
+   */
+  handleSlotChange() {
+    this.items = Array.from(this.querySelectorAll('auro-accordion'));
+  }
+
   // function that renders the HTML and CSS into  the scope of the component
   render() {
     return html`
-        <slot></slot>
+        <slot @slotchange=${this.handleSlotChange}></slot>
     `;
   }
 }

--- a/test/auro-accordion-group.test.js
+++ b/test/auro-accordion-group.test.js
@@ -1,10 +1,11 @@
-import { fixture, html, expect, waitUntil } from '@open-wc/testing';
+/* eslint-disable no-undef, no-unused-expressions, no-magic-numbers */
+import { fixture, html, expect } from '@open-wc/testing';
 import '../src/auro-accordion-group.js';
 import '../src/auro-accordion.js';
 
 describe('auro-accordion-group', () => {
   it('auro-accordion custom element is defined', async () => {
-    const el = await !!customElements.get("auro-accordion-group");
+    const el = await Boolean(customElements.get("auro-accordion-group"));
 
     await expect(el).to.be.true;
   });
@@ -25,12 +26,42 @@ describe('auro-accordion-group', () => {
         </auro-accordion>
       </auro-accordion-group>
     `);
-    
     const accordions = el.querySelectorAll('auro-accordion');
     const button = accordions[0].shadowRoot.querySelector('button');
+
     button.click();
 
     expect(accordions[0].expanded).to.be.true;
     expect(accordions[1].expanded).to.be.false;
-  })
+  });
+
+  it('reacts to slot changes', async () => {
+    const el = await fixture(html`
+      <auro-accordion-group></auro-accordion-group>
+    `);
+
+    // render accordion children after the group has connected
+    await fixture(html`
+      <auro-accordion id="epV">
+        <span slot="trigger">Star Wars: The Empire Strikes Back</span>
+        <p>It is a dark time for the Rebellion. Although the Death Star has been destroyed, Imperial troops have driven the Rebel forces from their hidden base and pursued them across the galaxy.</p>
+      </auro-accordion>
+      <auro-accordion id="epVI" expanded>
+        <span slot="trigger">Star Wars: Return of the Jedi</span>
+        <p>Luke Skywalker has returned to his home planet of Tatooine in an attempt to rescue his friend Han Solo from the clutches of the vile gangster Jabba the Hutt.</p>
+      </auro-accordion>
+      <auro-accordion id="epVII">
+        <span slot="trigger">Star Wars: The Force Awakens</span>
+        <p>Luke Skywalker has vanished. In his absence, the sinister FIRST ORDER has risen from the ashes of the Empire and will not rest until Skywalker, the last Jedi, has been destroyed.</p>
+      </auro-accordion>
+    `, { parentNode: el });
+
+    const accordions = el.querySelectorAll('auro-accordion');
+    const button = accordions[0].shadowRoot.querySelector('button');
+
+    button.click();
+
+    expect(accordions[0].expanded).to.be.true;
+    expect(accordions[1].expanded).to.be.false;
+  });
 });


### PR DESCRIPTION
# Alaska Airlines Pull Request

Fixes #18

## Summary:

- listen to slot changes so that items is kept up to date. Previously, items was only set when the element was first connected. This caused issues in frameworks like Svelte that first mounted the group, and then the children.
- add related test that failed before the changes and now passes

## Type of change:

- [x] Revision of an existing capability


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
