### PR TITLE
Create showOverflow to allow z-indexed content to display outside of the component

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -15,15 +15,15 @@ Use auro-accordion-group if you want to have auto closing accordion components w
 | `lowProfile`   | `Boolean` | Thinner version of auro-accordion w/o borders    |
 | `noProfile`    | `Boolean` | Thinner version of auro-accordion w/0 padding    |
 | `shade`        | `Boolean` | Accordion style with shade dropdown              |
+| `showOverflow` | `Boolean` | Allow .details content to overflow out of the accordion |
 | `warning`      | `Boolean` | Dependent on shade; warning styling              |
 
 ## Properties
 
-| Property      | Attribute     | Type      | Default | Description                                      |
-|---------------|---------------|-----------|---------|--------------------------------------------------|
-| `expanded`    | `expanded`    | `Boolean` | false   | Toggles the panel on and off                     |
-| `id`          | `id`          | `String`  |         | Used to generate the ID for the elements inside the component |
-| `noanimation` | `noanimation` | `Boolean` |         | Removes the animated opening and closing effect of the accordion |
+| Property   | Attribute  | Type      | Default | Description                                      |
+|------------|------------|-----------|---------|--------------------------------------------------|
+| `expanded` | `expanded` | `Boolean` | false   | Toggles the panel on and off                     |
+| `id`       | `id`       | `String`  |         | Used to generate the ID for the elements inside the component |
 
 ## Events
 

--- a/src/auro-accordion.js
+++ b/src/auro-accordion.js
@@ -29,7 +29,8 @@ import styleCssFixed from "./style-fixed-css.js";
  * @attr {Boolean} warning - Dependent on shade; warning styling
  * @attr {Boolean} error - Dependent on shade; error styling
  * @attr {Boolean} fixed - Uses px values instead of rem
- * @attr {Boolean} noanimation - Removes the animated opening and closing effect of the accordion
+ * @attr {Boolean} showOverflow - Allow .details content to overflow out of the accordion
+ * @attr @deprecated {Boolean} noanimation - Removes the animated opening and closing effect of the accordion
  * @attr {Boolean} noProfile - Thinner version of auro-accordion w/0 padding
  * @attr {Boolean} lowProfile - Thinner version of auro-accordion w/o borders
  * @attr {Boolean} justifyLeft - Places trigger content to the Left of the accordion
@@ -54,9 +55,6 @@ class AuroAccordion extends LitElement {
       expanded: {
         type: Boolean,
         reflect: true
-      },
-      noanimation: {
-        type: Boolean
       }
     };
   }

--- a/src/style.scss
+++ b/src/style.scss
@@ -321,6 +321,12 @@
   }
 }
 
+:host([showOverflow]) {
+  .details {
+    overflow: visible;
+  }
+}
+
 :host([noanimation]) {
   .details {
     overflow: auto;


### PR DESCRIPTION
create attr/prop to show overflow from the details of the accordion, and override any other defined overflow terms on a given accordion
set noanimation to reflect to prevent extra steps for consumers using Preact/Svelte/etc

**Fixes:** #39 

## Summary:

_Please summarize the scope of the changes you have submitted, what the intent of the work is and anything that describes the before/after state of the project._

## Type of change:

Please delete options that are not relevant.

- [x] New capability
- [x] Revision of an existing capability

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
