### PR TITLE
fix: resize content container when content is dynamically altered #130

### DIFF
--- a/src/auro-accordion.js
+++ b/src/auro-accordion.js
@@ -41,7 +41,7 @@ import tokensCss from "./tokens-css.js";
  * @csspart trigger - Apply CSS to trigger element.
  * @csspart chevron - Apply CSS to chevron icon.
  * @csspart content - Apply CSS to the accordion content.
- * @fires toggleExpanded - Notifies that the accordion has been expanded or closed.
+ * @event toggleExpanded - Notifies that the accordion has been expanded or closed.
  */
 
 // build the component class
@@ -141,19 +141,6 @@ export class AuroAccordion extends LitElement {
     }));
   }
 
-  /**
-   * Used to generate inline style heights of content so it animates correctly.
-   * @private
-   * @returns {void}
-   */
-  handleContentSlotChanges() {
-    const content = this.shadowRoot.querySelector(".content");
-    const container = this.shadowRoot.querySelector(".contentWrapper");
-    const height = container.offsetHeight;
-
-    content.style.height = `${height}px`;
-  }
-
   // function that renders the HTML and CSS into  the scope of the component
   render() {
     const buttonClasses = {
@@ -183,7 +170,7 @@ export class AuroAccordion extends LitElement {
         </auro-accordion-button>
         <div class="content" id="accordionContent" aria-labelledby="accordionTrigger" inert="${!this.expanded || nothing}" part="content">
           <div class="contentWrapper" part="contentWrapper">
-            <slot @slotchange="${this.handleContentSlotChanges}"></slot>
+            <slot></slot>
           </div>
         </div>
       </div>

--- a/src/style.scss
+++ b/src/style.scss
@@ -9,6 +9,8 @@
 @import './../node_modules/@aurodesignsystem/design-tokens/dist/tokens/SCSSVariables';
 
 :host {
+  interpolate-size: allow-keywords; // stylelint-disable-line
+
   .trigger {
     position: relative;
 
@@ -106,6 +108,12 @@
 :host([expanded="false"]) {
   .content  {
     height: 0 !important;
+  }
+}
+
+:host([expanded]) {
+  .content {
+    height: auto;
   }
 }
 


### PR DESCRIPTION
# Alaska Airlines Pull Request

## Type of change:

Please delete options that are not relevant.

- [ ] New capability
- [x] Revision of an existing capability
- [ ] Infrastructure change (automation, etc.)
- [ ] Other (please elaborate)


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

# Validation Help

Adding this code to firstUpdated will show the fix in this branch (or the bug in main)

    // BELOW IS A TEST TO CHANGE THE CONTENT LATER
    setTimeout(() => {
      const newElem = document.createElement('p');
      newElem.innerHTML = 'test';
      const container = this.shadowRoot.querySelector(".contentWrapper");
      container.appendChild(newElem);
    }, 3000);

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Fix the issue with content container resizing in the auro-accordion component by setting the content height to auto when expanded and removing the manual height calculation.

Bug Fixes:
- Fix the resizing of the content container when content is dynamically altered in the auro-accordion component.

Enhancements:
- Improve the handling of content slot changes by removing the manual height calculation and setting the content height to auto when expanded.