### PR TITLE
Update chevron-right non-emphasis styling

### DIFF
--- a/src/style.scss
+++ b/src/style.scss
@@ -86,6 +86,16 @@
   }
 }
 
+:host([chevron="right"]:not([emphasis])) {
+  ::slotted([slot="trigger"]) {
+    padding-left: var(--ds-size-250, $ds-size-250);
+  }
+
+  .contentWrapper {
+    padding-left: var(--ds-size-250, $ds-size-250);
+  }
+}
+
 :host([alignRight]) {
   .componentWrapper {
     display: flex;


### PR DESCRIPTION
# Alaska Airlines Pull Request

Resolves:
- #178


## Updates
- Add trigger component and content wrapper `padding-left` for variant chevron-right but not-emphasis.
```
:host([chevron="right"]:not([emphasis])) {
  ::slotted([slot="trigger"]) {
    padding-left: var(--ds-size-250, $ds-size-250);
  }

  .contentWrapper {
    padding-left: var(--ds-size-250, $ds-size-250);
  }
}
```

Taking example from the demo page, `chevron="right"`'s trigger component and content wrapper now has left padding.

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/6064e15e-66f2-4017-8436-356dfacf0631" />


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Update styling for non-emphasized chevron-right variant to add left padding to trigger component and content wrapper

Enhancements:
- Add left padding for trigger and content wrapper in chevron-right non-emphasis variant

Chores:
- Updated trigger padding right value from ds-size-200 to ds-size-250