### PR TITLE
fix: truncate trigger text on emphasis accordion #192

### DIFF
--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -27,11 +27,19 @@
     &:hover {
       text-decoration: underline;
     }
+
+    &[fluid] {
+      max-width: calc(100% - 3px); // 3px to account for borders
+    }
   }
 
   ::slotted([slot="trigger"]) {
     padding-left: var(--ds-size-100, vac.$ds-size-100);
     padding-right: var(--ds-size-200, vac.$ds-size-200);
+
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
   }
 
   .iconWrapper {


### PR DESCRIPTION
# Alaska Airlines Pull Request

### Issue
Accordion's ellipsis did not work because it was feeding multiple slots to a auro-button and those were filing in a flexbox. Although the flexbox had the ellipsis style set, due to the nature of flexbox, those ellipsis style does not get applied to children nodes.

### Solution
Accordion passes the slot with the proper ellipsis style set.

### Before
<img width="635" height="274" alt="image" src="https://github.com/user-attachments/assets/f216d2ae-92bf-40fb-9c8d-a24df6aa9fbc" />

### After
<img width="983" height="399" alt="image" src="https://github.com/user-attachments/assets/15214282-5e68-4406-a1c7-fc763b5b713b" />

closes #192 

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Implement text truncation and ellipsis for emphasis accordion triggers and add fluid width support

Bug Fixes:
- Fix trigger text truncation on emphasis accordion by wrapping the slot in a container with overflow settings

Enhancements:
- Add CSS overflow, whitespace, and text-overflow styles to truncate long trigger text with ellipsis
- Introduce [fluid] attribute styling to limit trigger slot width to 100% minus borders