### PR TITLE
fix: remove left-padding on trigger

### DIFF
--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -87,17 +87,7 @@
   }
 
   .contentWrapper {
-    padding-left: var(--ds-size-400, vac.$ds-size-400);
-  }
-}
-
-:host([chevron="right"]:not([emphasis])) {
-  ::slotted([slot="trigger"]) {
-    padding-left: var(--ds-size-250, vac.$ds-size-250);
-  }
-
-  .contentWrapper {
-    padding-left: var(--ds-size-250, vac.$ds-size-250);
+    padding-left: 0;
   }
 }
 


### PR DESCRIPTION
# Alaska Airlines Pull Request

1. remove on large emphasis accordion to match to design spec https://www.figma.com/design/VpUz89Ov6ImBpY5YvzYbZW/Auro-toolkit?node-id=11753-19436&m=dev

| Before | After | 
| -------- |  -------- |
| <img width="537" height="598" alt="image" src="https://github.com/user-attachments/assets/9b23d571-c4a9-4bd0-b980-81a881005630" /> | <img width="547" height="581" alt="image" src="https://github.com/user-attachments/assets/4c77d6fb-0634-416f-9c34-6c0ad364afe9" /> |


2. remove on right chevron accordion (but add margin to align with content)

| Before | After | 
| -------- |  -------- |
| <img width="522" height="439" alt="image" src="https://github.com/user-attachments/assets/7e2c6d3b-f38b-4e63-8b35-11c34a2f9831" /> | <img width="496" height="456" alt="image" src="https://github.com/user-attachments/assets/28cae76a-d9e6-4ce8-ae23-d38b0747b8b3" /> |

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Remove left-padding from accordion triggers and switch right-chevron variant to use margin for alignment

Enhancements:
- Replace padding-left with margin-left on right-chevron accordion triggers to align with content
- Remove left-padding on large emphasis accordion triggers and content wrapper

## Summary by Sourcery

Remove left-padding on accordion triggers and update right-chevron variant alignment to match design specifications

Enhancements:
- Remove left-padding from contentWrapper and trigger on large emphasis accordions
- Switch right-chevron accordion variant from padding-left to margin-left for correct alignment