### PR TITLE
fix(a11y): correct aria-expanded and delegate focus

### DIFF
--- a/src/auro-accordion.js
+++ b/src/auro-accordion.js
@@ -44,6 +44,15 @@ export class AuroAccordion extends LitElement {
   constructor() {
     super();
 
+    /**
+     * @private
+     * @property {boolean} delegatesFocus - Whether the shadow root delegates focus.
+     */
+    this.constructor.shadowRootOptions = {
+      ...LitElement.shadowRootOptions,
+      delegatesFocus: true,
+    };
+
     const versioning = new AuroDependencyVersioning();
 
     /**
@@ -270,7 +279,7 @@ export class AuroAccordion extends LitElement {
           class="${classMap(buttonClasses)}"
           id="accordionTrigger"
           aria-controls="${accordionContentId}"
-          ?ariaexpanded="${this.expanded}"
+          ?aria-expanded="${this.expanded}"
           ?aria-disabled="${this.disabled}"
           ?disabled="${this.disabled}"
           @click="${this.handleButtonClick}"

--- a/src/auro-accordion.js
+++ b/src/auro-accordion.js
@@ -41,17 +41,16 @@ import tokensCss from "./styles/tokens.scss";
 
 // build the component class
 export class AuroAccordion extends LitElement {
+  /**
+   * @private
+   */
+  static shadowRootOptions = {
+    ...LitElement.shadowRootOptions,
+    delegatesFocus: true,
+  };
+
   constructor() {
     super();
-
-    /**
-     * @private
-     * @property {boolean} delegatesFocus - Whether the shadow root delegates focus.
-     */
-    this.constructor.shadowRootOptions = {
-      ...LitElement.shadowRootOptions,
-      delegatesFocus: true,
-    };
 
     const versioning = new AuroDependencyVersioning();
 
@@ -177,7 +176,7 @@ export class AuroAccordion extends LitElement {
     if (changedProperties.has("expanded")) {
       const button = this.shadowRoot.querySelector("#accordionTrigger");
       if (button) {
-        button.ariaexpanded = this.expanded;
+        button.ariaExpanded = this.expanded;
       }
     }
   }
@@ -279,7 +278,7 @@ export class AuroAccordion extends LitElement {
           class="${classMap(buttonClasses)}"
           id="accordionTrigger"
           aria-controls="${accordionContentId}"
-          ?aria-expanded="${this.expanded}"
+          aria-expanded="${this.expanded}"
           ?aria-disabled="${this.disabled}"
           ?disabled="${this.disabled}"
           @click="${this.handleButtonClick}"
@@ -289,7 +288,7 @@ export class AuroAccordion extends LitElement {
           ${this.chevron === "right" ? this.renderChevronIcons() : nothing}
         </${this.buttonTag}>
         
-        <div class="content body-default" id="${accordionContentId}" aria-labelledby="accordionTrigger" inert="${!this.expanded || nothing}" part="content">
+        <div class="content body-default" id="${accordionContentId}" inert="${!this.expanded || nothing}" part="content">
           <div class="contentWrapper" part="contentWrapper">
             <slot></slot>
           </div>

--- a/test/auro-accordion.test.js
+++ b/test/auro-accordion.test.js
@@ -27,7 +27,6 @@ describe("auro-accordion", () => {
 
     await elementUpdated(trigger);
 
-    await expect(trigger.hasAttribute("ariaexpanded")).to.be.true;
     await expect(shadowButton.getAttribute("aria-expanded")).to.equal("true");
 
     trigger.click();


### PR DESCRIPTION
# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Review Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

<details>
<summary>
RC Checklist
</summary>

## Testing Checklist:

### Browsers

[Browsers Support Guide](https://auro.alaskaair.com/support/browsersSupport)

[Dev demo link](https://alaskaairlines.github.io/auro-accordion/)

Android

- [ ] Chrome
- [ ] Firefox

 iOS

- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Desktop

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

### Scenarios

- [ ] Validated linked issues with issue reporting team
- [ ] Test coverage report review

[Framework playground ](https://github.com/AlaskaAirlines/auro-framework-playground)

- [ ] Next React
- [ ] SvelteKit

</details><br>
**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Improve accessibility and focus behavior for the accordion component.

Bug Fixes:
- Correct the accordion trigger's ARIA attribute from `ariaexpanded` to the valid `aria-expanded` and remove an incorrect `aria-labelledby` reference from the content container.

Enhancements:
- Enable shadow DOM focus delegation on the accordion to improve keyboard focus handling for internal controls.